### PR TITLE
fix - mobile menu was not rendered in page

### DIFF
--- a/StylaSEO/Views/frontend/magazin/index.tpl
+++ b/StylaSEO/Views/frontend/magazin/index.tpl
@@ -4,6 +4,7 @@
     {include file='frontend/magazin/header.tpl'}
 {/block}
 
-{* Sidebar left - Disable added 151012 *}
-{block name="frontend_index_content_left"}
+{* Sidebar left *}
+{block name='frontend_index_content_left'}
+    {$smarty.block.parent}
 {/block}


### PR DESCRIPTION
Mobile menu was not rendered in the magazine page. This is a fix to this issue.

https://trello.com/c/EH4n5zyx/480-shopware-hamburger-menu-is-not-working-on-the-mobile-template