### PR TITLE
feat[2126]: curl failure fallback

### DIFF
--- a/StylaSEO/Components/Styla/Utils.php
+++ b/StylaSEO/Components/Styla/Utils.php
@@ -142,7 +142,8 @@ class StylaUtils{
             return $ret;
 
         }catch (Exception $e){
-            echo 'ERROR: '.$e->getMessage().' url:'.$url;
+            $ret['status_code'] = 500;
+            return $ret;
         }
 
     }


### PR DESCRIPTION
When curl request fails for some reasons, instead of throwing a fatal
error we now render the magazine anyway without SEO content.

https://trello.com/c/iqubVRsH/2126-shopware-improve-behaviour-when-curl-request-to-seo-api-fails-05md